### PR TITLE
fix: テンプレートExcelの必須シート不足を検出 #3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ logs/
 .vscode/
 work1/データ出力/
 config.ini
+work1/template/
+work1/売上データ元/

--- a/core/main_logic.py
+++ b/core/main_logic.py
@@ -10,6 +10,27 @@ from openpyxl import load_workbook
 from typing import Dict
 from openpyxl.workbook import Workbook
 
+# テンプレートに必要なシート
+REQUIRED_SHEETS = [
+    "データ統合",
+    "カテゴリ別売上",
+    "商品別売上",
+    "店舗別売上",
+    "日付別売上",
+]
+
+# テンプレートシートの検証関数
+def validate_template_sheets(wb: Workbook) -> None:
+    missing_sheets = [sheet for sheet in REQUIRED_SHEETS if sheet not in wb.sheetnames]
+    
+    if missing_sheets:
+        raise ValueError("テンプレートに必要なシートが不足しています：\n"
+                         f"必要シート：{', '.join(REQUIRED_SHEETS)}\n"
+                         f"不足シート：{', '.join(missing_sheets)}")
+
+
+
+
 # 売上ファイルを読み込んで結合データを作る関数
 def load_sales_files(input_folder : str) -> pd.DataFrame:
     logging.info("売上ファイルの読み込み開始")
@@ -105,6 +126,7 @@ def main(config) -> None:
 
         template_path = config["PATH"]["template_path"]
         wb = load_workbook(template_path)
+        validate_template_sheets(wb)
 
         # 統合データの書き込み
         write_df_to_sheet(wb, df, sheet_name="データ統合")


### PR DESCRIPTION
## 概要
テンプレートのExcelに指定のシートが存在しないとき、エラーが出るが、
何のシートが足りないかわかりにくいので、足りていないシートと必須シートの一覧を、
エラーとして出力するようにした。

## 変更内容
- main_logic.pyにvalidate_template_sheets()関数を作成した。

## 確認方法
- シート名を変更したテンプレートで、GUI、CLI実行で不足シートの一覧と必須シートの一覧がエラー出力されることを確認

Closes #3 
